### PR TITLE
[PUX-2781] Add support for ObjC enum

### DIFF
--- a/RTNTrueLayerPaymentsSDK/ios/RTNTrueLayerPaymentsSDK.mm
+++ b/RTNTrueLayerPaymentsSDK/ios/RTNTrueLayerPaymentsSDK.mm
@@ -14,7 +14,7 @@ RCT_EXPORT_MODULE()
   // The Objective-C environment to convert the `NSString` `environment` value to,
   // so it can be passed to the Objective-C bridge of the TrueLayer SDK.
   TrueLayerObjectiveCEnvironment objCEnvironment;
-  environment = @"test";
+
   if (environment && [environment caseInsensitiveCompare:@"sandbox"] == NSOrderedSame) {
     objCEnvironment = TrueLayerObjectiveCEnvironmentSandbox;
   } else if (environment && [environment caseInsensitiveCompare:@"production"] == NSOrderedSame) {


### PR DESCRIPTION
[We added an objC environment enum in the public SDK](https://github.com/TrueLayer/TrueLayer-iOS-SDK/pull/24), so this PR updates the react native app to use that instead of passing a String.