### PR TITLE
[PUX-2806] Add additional configuration

### DIFF
--- a/RTNTrueLayerPaymentsSDK/ios/RTNTrueLayerPaymentsSDK.mm
+++ b/RTNTrueLayerPaymentsSDK/ios/RTNTrueLayerPaymentsSDK.mm
@@ -38,7 +38,7 @@ RCT_EXPORT_MODULE()
   }
 
   NSDictionary *additionalConfiguration = @{
-    [TrueLayerObjectiveCAdditionalConfigurationKey integrationType]: @"react-native",
+    [TrueLayerObjectiveCAdditionalConfigurationKey integrationType]: @"React Native",
     [TrueLayerObjectiveCAdditionalConfigurationKey integrationVersion]: @"1.0.0"
   };
 


### PR DESCRIPTION
Adds passing the integration type and version to the public SDK's objC bridge.