### PR TITLE
[PUX-2834] Remove dev branch from Demoapp podfile

### DIFF
--- a/DemoApp/ios/Podfile
+++ b/DemoApp/ios/Podfile
@@ -6,9 +6,6 @@ install! 'cocoapods', :deterministic_uuids => false
 
 target 'DemoApp' do
   config = use_native_modules!
-  
-  # This is temporarily added here to point to the specific development branch for iOS, while we build the Objective-C bridging.
-  pod 'TrueLayerPaymentsSDK', :git => 'https://github.com/TrueLayer/TrueLayer-iOS-SDK.git', :branch => 'feature/PUX-2602-react-native-bridge'
 
   # Flags change depending on the env values.
   flags = get_default_flags()


### PR DESCRIPTION
Merge this once the Objective-C bridge [branch](https://github.com/TrueLayer/TrueLayer-iOS-SDK/tree/feature/PUX-2602-react-native-bridge) is merged to the public repo. That's this branch on the public repo: https://github.com/TrueLayer/TrueLayer-iOS-SDK/tree/feature/PUX-2602-react-native-bridge