### PR TITLE
[PUX-2856] Add errors for checking for nil values

### DIFF
--- a/RNTrueLayerPaymentsSDK/ios/RNTrueLayerPaymentsSDK.mm
+++ b/RNTrueLayerPaymentsSDK/ios/RNTrueLayerPaymentsSDK.mm
@@ -171,7 +171,8 @@ RCT_EXPORT_MODULE()
     UIViewController *reactViewController = RCTPresentedViewController();
 
     // Create the context required by the ObjC bridge in TrueLayerSDK.
-    TrueLayerPresentationStyle *presentationStyle = [[TrueLayerPresentationStyle alloc] initWithPresentOn:reactViewController style:UIModalPresentationAutomatic];
+    TrueLayerPresentationStyle *presentationStyle = [[TrueLayerPresentationStyle alloc] initWithPresentOn:reactViewController
+                                                                                                    style:UIModalPresentationAutomatic];
     TrueLayerMandatePreferences *preferences = [[TrueLayerMandatePreferences alloc] initWithPresentationStyle:presentationStyle];
     TrueLayerMandateContext *context = [[TrueLayerMandateContext alloc] initWithIdentifier:mandateID
                                                                                      token:resourceToken


### PR DESCRIPTION
Having trouble running the React Native app, but the rn-truelayer-payments-sdk framework builds.

- Creates a new method to create an error from a given description, reason, etc.
- Calls this method whenever we check for payment IDs, resource tokens, etc. to ensure they are non-nil.
- Change style to match Google guidelines