### PR TITLE
[FEATURE] Update README and DOCUMENTATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Using npm:
 
 `npm install rn-truelayer-payments-sdk --save`
 
+In your iOS folder, run the Cocoapods install command:
+
+- If using the [New Architecture](https://reactnative.dev/docs/new-architecture-intro), run:
+
+	```
+	RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
+	```
+- If using the old architecture, run:
+
+	```
+	bundle exec pod install
+	```
+
 ## Setup
 
 ### Prerequisites

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -4,6 +4,8 @@ This a high level documentation on how to use the React Native TrueLayer SDK.
 
 Once your app has obtained the payment (or mandate) identifier and resource token from the backend (see [Setup](../README.md)), you can use the React Native SDK to process the payment.
 
+> Note: when processing a single payment or mandate, ensure the top-most view that is visible *remains* in memory. It should not be hidden or deallocated while the SDK is displayed. The iOS SDK keeps a reference to this view to dismiss itself when the flow is complete.
+
 ## Single Payment
 
 ### Creating a payment


### PR DESCRIPTION
Updates README and DOCUMENTATION to include pod install and note about retaining the presenting view. This is required so the iOS SDK can use the view to dismiss the UI.