### PR TITLE
[FEATURE] Add signupPlus support to iOS

### DIFF
--- a/DemoApp/App.tsx
+++ b/DemoApp/App.tsx
@@ -116,7 +116,7 @@ function processPayment(): void {
         redirectUri: 'truelayer://payments_sample',
       },
       {
-        paymentUseCase: PaymentUseCase.Default,
+        paymentUseCase: PaymentUseCase.Send,
       },
     ).then(result => {
       switch (result.type) {

--- a/DemoApp/ios/Podfile
+++ b/DemoApp/ios/Podfile
@@ -10,6 +10,8 @@ target 'DemoApp' do
   # Flags change depending on the env values.
   flags = get_default_flags()
 
+  pod 'TrueLayerPaymentsSDK', :git => 'https://github.com/TrueLayer/TrueLayer-iOS-SDK.git', :branch => 'release/2.4.0'
+
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -777,6 +777,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - rn-truelayer-payments-sdk (from `../node_modules/rn-truelayer-payments-sdk`)
+  - TrueLayerPaymentsSDK (from `https://github.com/TrueLayer/TrueLayer-iOS-SDK.git`, branch `release/2.4.0`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -795,7 +796,6 @@ SPEC REPOS:
     - libevent
     - OpenSSL-Universal
     - SocketRocket
-    - TrueLayerPaymentsSDK
     - YogaKit
 
 EXTERNAL SOURCES:
@@ -875,8 +875,16 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   rn-truelayer-payments-sdk:
     :path: "../node_modules/rn-truelayer-payments-sdk"
+  TrueLayerPaymentsSDK:
+    :branch: release/2.4.0
+    :git: https://github.com/TrueLayer/TrueLayer-iOS-SDK.git
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
+
+CHECKOUT OPTIONS:
+  TrueLayerPaymentsSDK:
+    :commit: bee70152d436b0e90ae844d98e8d45ce72724633
+    :git: https://github.com/TrueLayer/TrueLayer-iOS-SDK.git
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
@@ -935,6 +943,6 @@ SPEC CHECKSUMS:
   Yoga: eca980a5771bf114c41a754098cd85e6e0d90ed7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: f031d28059765713ce5e10f73a0d172aa3e4739f
+PODFILE CHECKSUM: 76a6f23630f9fc11851ee09ba70a0cd6207d20c1
 
 COCOAPODS: 1.11.3

--- a/RNTrueLayerPaymentsSDK/ios/RNTrueLayerPaymentsSDK.mm
+++ b/RNTrueLayerPaymentsSDK/ios/RNTrueLayerPaymentsSDK.mm
@@ -277,23 +277,23 @@ RCT_EXPORT_METHOD(_mandateStatus:(NSString *)mandateId
     // We use the main thread here as `RCTPresentedViewController.init` accesses the main application window.
     UIViewController *reactViewController = RCTPresentedViewController();
 
-    TrueLayerTransactionUseCase transactionUseCase;
-    
+    TrueLayerSinglePaymentUseCase useCase;
+
     if ((paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"Default"] == NSOrderedSame) ||
         (paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"Send"] == NSOrderedSame)) {
-      transactionUseCase = TrueLayerTransactionUseCaseSend;
+      useCase = TrueLayerSinglePaymentUseCaseSend;
     } else if (paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"SignUpPlus"] == NSOrderedSame) {
-      transactionUseCase = TrueLayerTransactionUseCaseSignupPlus;
+      useCase = TrueLayerSinglePaymentUseCaseSignupPlus;
     } else {
-      transactionUseCase = TrueLayerTransactionUseCaseSend;
+      useCase = TrueLayerSinglePaymentUseCaseSend;
     }
-    
+
     // Create the context required by the ObjC bridge in TrueLayerSDK.
     TrueLayerPresentationStyle *presentationStyle = [[TrueLayerPresentationStyle alloc] initWithPresentOn:reactViewController
                                                                                                     style:UIModalPresentationAutomatic];
     TrueLayerSinglePaymentPreferences *trueLayerPreferences = [[TrueLayerSinglePaymentPreferences alloc] initWithPresentationStyle:presentationStyle
                                                                                                               preferredCountryCode:preferredCountryCode
-                                                                                                                transactionUseCase:transactionUseCase];
+                                                                                                                useCase:useCase];
     TrueLayerSinglePaymentContext *context = [[TrueLayerSinglePaymentContext alloc] initWithIdentifier:paymentId
                                                                                                  token:resourceToken
                                                                                            redirectURL:[NSURL URLWithString:redirectURI]

--- a/RNTrueLayerPaymentsSDK/ios/RNTrueLayerPaymentsSDK.mm
+++ b/RNTrueLayerPaymentsSDK/ios/RNTrueLayerPaymentsSDK.mm
@@ -279,8 +279,7 @@ RCT_EXPORT_METHOD(_mandateStatus:(NSString *)mandateId
 
     TrueLayerSinglePaymentUseCase useCase;
 
-    if ((paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"Default"] == NSOrderedSame) ||
-        (paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"Send"] == NSOrderedSame)) {
+    if (paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"Send"] == NSOrderedSame) {
       useCase = TrueLayerSinglePaymentUseCaseSend;
     } else if (paymentUseCase && [paymentUseCase caseInsensitiveCompare:@"SignUpPlus"] == NSOrderedSame) {
       useCase = TrueLayerSinglePaymentUseCaseSignupPlus;

--- a/RNTrueLayerPaymentsSDK/js/models/payments/PaymentUseCase.ts
+++ b/RNTrueLayerPaymentsSDK/js/models/payments/PaymentUseCase.ts
@@ -1,5 +1,4 @@
 export enum PaymentUseCase {
-  Default = "Default",
   Send = "Send",
   SignUpPlus = "SignUpPlus",
 }

--- a/RNTrueLayerPaymentsSDK/js/models/types.ts
+++ b/RNTrueLayerPaymentsSDK/js/models/types.ts
@@ -1,11 +1,11 @@
 import { MandateStatus } from "./mandates/MandateStatus";
 import { PaymentStatus } from "./payments/PaymentStatus";
 
-export type { PaymentStatus, MandateStatus };
+export { PaymentStatus, MandateStatus };
 
 export type { PaymentContext } from "./payments/PaymentContext";
 
-export type { PaymentUseCase } from "./payments/PaymentUseCase";
+export { PaymentUseCase } from "./payments/PaymentUseCase";
 
 export type { MandateContext } from "./mandates/MandateContext";
 


### PR DESCRIPTION
- Adds support for passing the Signup+ `paymentUseCase` to the iOS SDK via the Objective-C bridge.
- Remove `Default` from `PaymentUseCase`
- Changes `export type` to `export` for enums

https://user-images.githubusercontent.com/100143043/224010509-6bdf2582-4f8d-4c85-b86c-37fbd0b311c4.mp4


