### PR TITLE
fix types exports

### DIFF
--- a/RNTrueLayerPaymentsSDK/js/models/types.ts
+++ b/RNTrueLayerPaymentsSDK/js/models/types.ts
@@ -1,25 +1,23 @@
 import { MandateStatus } from "./mandates/MandateStatus";
 import { PaymentStatus } from "./payments/PaymentStatus";
 
-export { PaymentContext } from "./payments/PaymentContext";
+export type { PaymentStatus, MandateStatus };
 
-export { PaymentStatus } from "./payments/PaymentStatus";
+export type { PaymentContext } from "./payments/PaymentContext";
 
-export { PaymentUseCase } from "./payments/PaymentUseCase";
+export type { PaymentUseCase } from "./payments/PaymentUseCase";
 
-export { MandateContext } from "./mandates/MandateContext";
+export type { MandateContext } from "./mandates/MandateContext";
 
-export { MandateStatus } from "./mandates/MandateStatus";
+export type { PaymentPreferences } from "./payments/PaymentPreferences";
 
-export { PaymentPreferences } from "./payments/PaymentPreferences";
+export type { MandatePreferences } from "./mandates/MandatePreferences";
 
-export { MandatePreferences } from "./mandates/MandatePreferences";
+export type { Theme } from "./theme/Theme";
 
-export { Theme } from "./theme/Theme";
+export type { AndroidColors } from "./theme/AndroidColors";
 
-export { AndroidColors } from "./theme/AndroidColors";
-
-export { AndroidTypography } from "./theme/AndroidTypography";
+export type { AndroidTypography } from "./theme/AndroidTypography";
 
 /**
  * Defines available environments


### PR DESCRIPTION
The PR aims to fix the export of the type in typescript, `export type { /* ... */ } from`
The syntax proposed avoid to be thrown an error when trying to access it.