### PR TITLE
[Fix] Config for releasing new versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
                 command: |
                   echo "This is a dry run: parameters.isDryRun is true."
       - when:
-          condition: not <<parameters.isDryRun>>
+          condition: not << parameters.isDryRun >>
           steps:
             - run:
                 name: Publish to npm (actual)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,9 @@ jobs:
                 command: |
                   echo "This is a dry run: parameters.isDryRun is true."
       - when:
-          condition: not << parameters.isDryRun >>
+          condition:
+            and:
+              - not: << parameters.isDryRun >>
           steps:
             - run:
                 name: Publish to npm (actual)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,37 @@ jobs:
                   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
                   npm publish
 
+  build-and-publish-test:
+    executor: node/default
+    working_directory: ~/project/RNTrueLayerPaymentsSDK
+    parameters:
+      isDryRun:
+        type: boolean
+        default: true
+    steps:
+      - checkout:
+          path: ~/project
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          name: Build SDK
+          command: yarn build
+      - when:
+          condition: << parameters.isDryRun >>
+          steps:
+            - run:
+                name: Publish to npm (dry run)
+                command: |
+                  echo "This is a dry run: parameters.isDryRun is true."
+      - when:
+          condition: not <<parameters.isDryRun>>
+          steps:
+            - run:
+                name: Publish to npm (actual)
+                command: |
+                  echo "This is the real test run: parameters.isDryRun is false."
+
+
 workflows:
   version: 2
   verify-version:
@@ -64,6 +95,33 @@ workflows:
           filters: *release_branch_filter
           requires:
             - verify-package-version
+            
+  test-config-yaml-changes:
+    jobs:
+      - build-and-publish-test:
+          name: build-and-publish-test-dry-run
+          isDryRun: true
+          filters:
+            branches:
+              only:
+                - feature/test-config-yaml-update-for-tag
+      - approval:
+          type: approval
+          requires:
+            - build-and-publish-test-dry-run
+          filters:
+            branches:
+              only:
+                - feature/test-config-yaml-update-for-tag
+      - build-and-publish-test:
+          name: build-and-publish-test-real
+          isDryRun: false
+          requires:
+            - approval
+          filters:
+            branches:
+              only:
+                - feature/test-config-yaml-update-for-tag
 
   build-and-publish-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,37 +41,6 @@ jobs:
                   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
                   npm publish --dry-run
       - unless:
-          condition: not <<parameters.isDryRun>>
-          steps:
-            - run:
-                name: Publish to npm (actual)
-                command: |
-                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-                  npm publish
-
-  build-and-publish-test:
-    executor: node/default
-    working_directory: ~/project/RNTrueLayerPaymentsSDK
-    parameters:
-      isDryRun:
-        type: boolean
-        default: true
-    steps:
-      - checkout:
-          path: ~/project
-      - node/install-packages:
-          pkg-manager: yarn
-      - run:
-          name: Build SDK
-          command: yarn build
-      - when:
-          condition: << parameters.isDryRun >>
-          steps:
-            - run:
-                name: Publish to npm (dry run)
-                command: |
-                  echo "This is a dry run: parameters.isDryRun is true."
-      - when:
           condition:
             and:
               - not: << parameters.isDryRun >>
@@ -79,8 +48,8 @@ jobs:
             - run:
                 name: Publish to npm (actual)
                 command: |
-                  echo "This is the real test run: parameters.isDryRun is false."
-
+                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+                  npm publish
 
 workflows:
   version: 2
@@ -97,33 +66,6 @@ workflows:
           filters: *release_branch_filter
           requires:
             - verify-package-version
-            
-  test-config-yaml-changes:
-    jobs:
-      - build-and-publish-test:
-          name: build-and-publish-test-dry-run
-          isDryRun: true
-          filters:
-            branches:
-              only:
-                - feature/test-config-yaml-update-for-tag
-      - approval:
-          type: approval
-          requires:
-            - build-and-publish-test-dry-run
-          filters:
-            branches:
-              only:
-                - feature/test-config-yaml-update-for-tag
-      - build-and-publish-test:
-          name: build-and-publish-test-real
-          isDryRun: false
-          requires:
-            - approval
-          filters:
-            branches:
-              only:
-                - feature/test-config-yaml-update-for-tag
 
   build-and-publish-workflow:
     jobs:


### PR DESCRIPTION
This PR updates the CircleCI config.yml to fix the release steps. The `condition: not <<parameters.isDryRun>>`  was not being evaluated properly, so the package is never published. This fixes the syntax so it does.

See [here](https://support.circleci.com/hc/en-us/articles/360043638052-Conditional-steps-in-jobs-and-conditional-workflows) for the official syntax.

Check [this workflow](https://app.circleci.com/pipelines/github/TrueLayer/truelayer-react-native-sdk/58/workflows/dcdf6e73-9431-4fdf-95b2-b76edb4a4cb3/jobs/48) and commit to see the dry run, approval, then actual publishing steps being carried out. It prints in the script rather than publishing.