### PR TITLE
[Fix] InvalidRedirectURI error mapping in Objective-C

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
                 command: |
                   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
                   npm publish --dry-run
-      - unless:
+      - when:
           condition:
             and:
               - not: << parameters.isDryRun >>

--- a/DemoApp/ios/Podfile
+++ b/DemoApp/ios/Podfile
@@ -39,5 +39,13 @@ target 'DemoApp' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    # Workaround for Xcode 14.3:
+    # https://github.com/facebook/react-native/issues/34106#issuecomment-1417685116
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.4'
+      end
+    end
   end
 end

--- a/RNTrueLayerPaymentsSDK/ios/RNTrueLayerHelpers.mm
+++ b/RNTrueLayerPaymentsSDK/ios/RNTrueLayerHelpers.mm
@@ -34,7 +34,10 @@
     
   case TrueLayerSinglePaymentErrorGeneric:
     return @"Unknown";
-    
+
+  case TrueLayerSinglePaymentErrorInvalidRedirectURI:
+    return @"InvalidRedirectURI";
+
   case TrueLayerSinglePaymentErrorInvalidToken:
     return @"ConnectionSecurityIssue";
     
@@ -114,7 +117,10 @@
     
   case TrueLayerMandateErrorMandateExpired:
     return @"PaymentFailed";
-    
+
+  case TrueLayerMandateErrorInvalidRedirectURI:
+    return @"InvalidRedirectURI";
+
   case TrueLayerMandateErrorMandateNotFound:
     return @"PaymentFailed";
     

--- a/RNTrueLayerPaymentsSDK/js/models/types.ts
+++ b/RNTrueLayerPaymentsSDK/js/models/types.ts
@@ -49,6 +49,7 @@ export type FailureReason =
   | "UserAborted"
   | "CommunicationIssue"
   | "ConnectionSecurityIssue"
+  | "InvalidRedirectURI"
   | "PaymentFailed"
   | "WaitAbandoned"
   | "ProcessorContextNotAvailable"

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -169,6 +169,7 @@ The `processPayment` and `processMandate` methods return a `ProcessorResult` typ
 | `Unknown`                      | The `SDK` encountered an unexpected behavior.                                                                                                                                                                                                                                     |
 | `UserAborted`                  | The user canceled the payment or mandate.                                                                                                                                                                                                                                         |
 | `ProviderOffline`                  | The pre-selected provider was offline.                                                                                                                                                                                                                                   |
+| `InvalidRedirectURI`                  | The redirect URI passed to the SDK is invalid.                                                                                                                                                                                                                                   |
 ## Customising the UI
 You can customise the colors and fonts used within the SDK. Customisation options are unique for iOS and Android and must be passed when processing a payment or mandate.
 


### PR DESCRIPTION
- Maps the `invalidRedirectURI` errors to a new error in the React Native SDK, `InvalidRedirectURI`.
- Updates the Documentation for this new error.
- Adds a workaround for an issue with Xcode 14.3, where some of the React Native dependencies target iOS 11. The workaround changes the Pods to target iOS 12.4, which is the point where they'll compile.

Verified it compiles:

https://github.com/TrueLayer/truelayer-react-native-sdk/assets/100143043/0c07f8ca-0b9d-4e8c-bc70-3386c74e3bd2

