### PR TITLE
Update TlPaymentSdkModule.kt

### DIFF
--- a/RNTrueLayerPaymentsSDK/android/src/main/java/com/truelayer/RNTrueLayerPaymentsSDK/TlPaymentSdkModule.kt
+++ b/RNTrueLayerPaymentsSDK/android/src/main/java/com/truelayer/RNTrueLayerPaymentsSDK/TlPaymentSdkModule.kt
@@ -526,7 +526,7 @@ class TlPaymentSdkModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    override fun onNewIntent(p0: Intent?) {
+    override fun onNewIntent(p0: Intent) {
     }
 
     override fun getConstants(): Map<String, Any> {


### PR DESCRIPTION
React Native 0.80 introduced changes to the Android/Kotlin API which updated the method signature for onNewIntent. The parameter is now defined as a non-nullable Intent instead of a nullable Intent?.

This is to resolve the issue as described here in [#88]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `onNewIntent` override to use non-null `Intent` parameter to align with updated React Native Android API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae02ee6fd0b753b47f1b3790ad1bdfe6bdfda698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->