### PR TITLE
Non optional theme on iOS

### DIFF
--- a/RNTrueLayerPaymentsSDK/js/TrueLayerPaymentsSDKWrapper.ts
+++ b/RNTrueLayerPaymentsSDK/js/TrueLayerPaymentsSDKWrapper.ts
@@ -28,7 +28,7 @@ export abstract class TrueLayerPaymentsSDKWrapper {
    */
   static configure(
     environment: Environment = Environment.Production,
-    theme?: Theme
+    theme: Theme
   ): Promise<void> {
     return RNTrueLayerPaymentsSDK!!._configure(environment, theme);
   }


### PR DESCRIPTION
When using `TrueLayerPaymentsSDKWrapper.configure()` without a theme the application crashes on iOS. 